### PR TITLE
Fix code scanning alert no. 24: Resource injection

### DIFF
--- a/WebGoat/App_Code/DB/SqliteDbProvider.cs
+++ b/WebGoat/App_Code/DB/SqliteDbProvider.cs
@@ -21,7 +21,10 @@ namespace OWASP.WebGoat.NET.App_Code.DB
 
         public SqliteDbProvider(ConfigFile configFile)
         {
-            _connectionString = string.Format("Data Source={0};Version=3", configFile.Get(DbConstants.KEY_FILE_NAME));
+            var builder = new SqliteConnectionStringBuilder();
+            builder.DataSource = configFile.Get(DbConstants.KEY_FILE_NAME);
+            builder.Version = 3;
+            _connectionString = builder.ConnectionString;
 
             _clientExec = configFile.Get(DbConstants.KEY_CLIENT_EXEC);
             _dbFileName = configFile.Get(DbConstants.KEY_FILE_NAME);


### PR DESCRIPTION
Fixes [https://github.com/dhir-chandan-webjet/ghas-demo-csharp/security/code-scanning/24](https://github.com/dhir-chandan-webjet/ghas-demo-csharp/security/code-scanning/24)

To fix the problem, we should avoid directly using user input in constructing the connection string. Instead, we can use a connection string builder class, such as `SqliteConnectionStringBuilder`, to safely construct the connection string. This approach ensures that any special characters in the user input are properly escaped, preventing resource injection attacks.

1. Replace the direct construction of the connection string with the use of `SqliteConnectionStringBuilder`.
2. Update the constructor of `SqliteDbProvider` to use `SqliteConnectionStringBuilder` for constructing the connection string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
